### PR TITLE
Support various delivery options

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ServiceX DataBinder
 
-<p align="right"> Release v0.4.1 </p>
+<p align="right"> Release v0.5.0 </p>
 
 [![PyPI version](https://badge.fury.io/py/servicex-databinder.svg)](https://badge.fury.io/py/servicex-databinder)
 
@@ -65,23 +65,26 @@ The followings are available options:
 
 <!-- `General` block: -->
 | Option for `General` block | Description       | DataType |
-|:--------:|:------:|:------|
+|:--------:|:------|:------|
 | `ServiceXName`* | ServiceX backend name in your `servicex.yaml` file <br>  | `String` |
-| `OutputDirectory` | Path to the directory for ServiceX delivered files | `String` |
 | `OutputFormat`* | Output file format of ServiceX delivered data (`parquet` or `root` for `uproot` / `root` for `xaod`) | `String` |
+| `Transformer` | Set transformer for all Samples. Overwrites the default transformer in the `servicex.yaml` file.  | `String`|
+| `Delivery` | Delivery option; `LocalPath` (default) or `LocalCache` or `ObjectStore` | `String` |
+| `OutputDirectory` | Path to a directory for ServiceX delivered files | `String` |
 | `WriteOutputDict` | Name of an ouput yaml file containing Python nested dictionary of output file paths (located in the `OutputDirectory`) | `String` |
 | `IgnoreServiceXCache` | Ignore the existing ServiceX cache and force to make ServiceX requests | `Boolean` |
 <p align="right"> *Mandatory options</p>
 
 | Option for `Sample` block | Description       |DataType |
-|:--------:|:------:|:------|
-| `Name`   | sample name defined by a user |`String` |
+|:--------:|:------|:------|
+| `Name`   | Sample name defined by a user |`String` |
+| `Transformer` | Transformer for the given sample | `String`|
 | `RucioDID` | Rucio Dataset Id (DID) for a given sample; <br> Can be multiple DIDs separated by comma |`String` |
 | `XRootDFiles` | XRootD files (e.g. `root://`) for a given sample; <br> Can be multiple files separated by comma |`String` |
 | `Tree` | Name of the input ROOT `TTree`; <br> Can be multiple `TTree`s separated by comma (`uproot` ONLY) |`String` |
 | `Filter` | Selection in the TCut syntax, e.g. `jet_pt > 10e3 && jet_eta < 2.0` (TCut ONLY) |`String` |
 | `Columns` | List of columns (or branches) to be delivered; multiple columns separately by comma (TCut ONLY) |`String` |
-| `FuncADL` | func-adl expression for a given sample |`String` |
+| `FuncADL` | Func-adl expression for a given sample |`String` |
 | `LocalPath` | File path directly from local path (NO ServiceX tranformation) | `String` |
 
  <!-- Options exclusively for TCut syntax (CANNOT combine with the option `FuncADL`) -->

--- a/servicex_databinder/__init__.py
+++ b/servicex_databinder/__init__.py
@@ -2,7 +2,7 @@ import logging
 
 from .servicex_databinder import DataBinder # NOQA
 
-__version__ = '0.4.1'
+__version__ = '0.5.0'
 
 logging.basicConfig(format="%(levelname)s - %(message)s")
 logging.getLogger(__name__).setLevel(logging.INFO)

--- a/servicex_databinder/configuration.py
+++ b/servicex_databinder/configuration.py
@@ -32,7 +32,7 @@ def LoadConfig(input_config:
             _validate_config(config)
             return _update_backend_per_sample(config)
         except Exception:
-            raise FileNotFoundError(
+            raise SyntaxError(
                 f"Exception occured while reading config file: {file_path}"
                 )
 
@@ -115,6 +115,7 @@ def _validate_config(config: Dict[str, Any]) -> bool:
         bool: whether the validation was successful
     """
 
+    # Check Option names
     available_keys = [
         'General', 'ServiceXName', 'OutputDirectory', 'Transformer',
         'OutputFormat', 'WriteOutputDict', 'Name',
@@ -139,15 +140,18 @@ def _validate_config(config: Dict[str, Any]) -> bool:
         if key not in available_keys:
             raise KeyError(f"Unknown Option {key} in the config")
 
+    # Check General block option values
+    if 'Delivery' in config['General'].keys():
+        if config['General']['Delivery'] not in [
+                'localpath, localcache', 'objectstore']:
+            raise ValueError(
+                f"Unsupported delivery option: {config['General']['Delivery']}"
+                f" - supported options: LocalPath, LocalCache, ObjectStore"
+                )
+
     if ('ServiceXName' not in config['General'].keys()) and \
             ('ServiceXBackendName' not in config['General'].keys()):
         raise KeyError("Option 'ServiceXName' is required in General block")
-
-    # if 'Transformer' not in config['General'].keys():
-    #     raise KeyError("Option 'Transformer' is required in General block")
-
-    # if 'OutputDirectory' not in config['General'].keys():
-    #     raise KeyError("OutputDirectory is required")
 
     if 'OutputFormat' not in config['General'].keys():
         raise KeyError("OutputFormat is required")

--- a/servicex_databinder/get_servicex_data.py
+++ b/servicex_databinder/get_servicex_data.py
@@ -1,10 +1,8 @@
-# from pathlib import Path
 from typing import Any, Dict, List
 import logging
 
 from aiohttp import ClientSession
 import asyncio
-# from shutil import copy
 from tqdm.asyncio import tqdm
 
 from servicex import ServiceXDataset, utils, servicex_config
@@ -45,10 +43,8 @@ class DataBinderDataset:
 
     async def deliver_and_copy(self, req):
         if req['codegen'] == "uproot":
-            # target_path = Path(self.output_path, req['Sample'], req['tree'])
             title = f"{req['Sample']} - {req['tree']}"
         elif req['codegen'] == "atlasr21":
-            # target_path = Path(self.output_path, req['Sample'])
             title = f"{req['Sample']}"
 
         if self._progresbar:
@@ -75,7 +71,7 @@ class DataBinderDataset:
                         title=title
                         )
                 elif self._outputformat == "root":
-                    files = await sx_ds.get_data_parquet_async(
+                    files = await sx_ds.get_data_rootfiles_async(
                         query,
                         title=title
                         )
@@ -94,8 +90,7 @@ class DataBinderDataset:
         # Update Outfile paths dictionary
         # - add files based on the returned file list from ServiceX
         self.update_out_paths_dict(req, files, self._outputformat)
-
-        return self.output_handler.copy_to_target(req, files)
+        self.output_handler.copy_to_target(req, files)
 
     async def get_data(self, overall_progress_only):
         log.info(f"Deliver via ServiceX endpoint: {self.endpoint}")
@@ -121,7 +116,7 @@ class DataBinderDataset:
                 pbar.set_description(value)
                 pbar.update()
             else:
-                log.info(value)
+                pass
 
         if overall_progress_only:
             pbar.close()


### PR DESCRIPTION
- Support various delivery options: `LocalPath` is the default setting and delivers to the (user-specified) local path. `LocalCache` downloads files from ServiceX but generates file list from the files in local cache. `ObjectStore` returns file paths in ServiceX object store and DataBinder generates file list of s3 paths.
- First version uses data format dependent `get_data_X` functions of ServiceX frontend. Thus, no more parquet-to-root conversion locally. (caveat: tree name is not propagated to the delivered root file)